### PR TITLE
Performance optimizations: DB index, poller concurrency, pagination, dedup

### DIFF
--- a/backend/core_service/db/migrations/000008_add_user_preferences_index.down.sql
+++ b/backend/core_service/db/migrations/000008_add_user_preferences_index.down.sql
@@ -1,0 +1,2 @@
+-- Drop index on user_preferences.user_id
+DROP INDEX IF EXISTS idx_user_preferences_user_id;

--- a/backend/core_service/db/migrations/000008_add_user_preferences_index.up.sql
+++ b/backend/core_service/db/migrations/000008_add_user_preferences_index.up.sql
@@ -1,0 +1,2 @@
+-- Add index for faster user_preferences lookups by user_id
+CREATE INDEX IF NOT EXISTS idx_user_preferences_user_id ON user_preferences(user_id);

--- a/backend/core_service/internal/clients/github_client.go
+++ b/backend/core_service/internal/clients/github_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"core-service/internal/middleware"
@@ -76,6 +77,8 @@ func (c *GitHubClient) SearchRepos(
 	domains string,
 	nameQuery string,
 	token string,
+	page int,
+	limit int,
 ) ([]GitHubRepo, error) {
 
 	if c.baseURL == "" {
@@ -90,6 +93,8 @@ func (c *GitHubClient) SearchRepos(
 	if nameQuery != "" {
 		params.Set("q", nameQuery)
 	}
+	params.Set("page", strconv.Itoa(page))
+	params.Set("limit", strconv.Itoa(limit))
 
 	req, err := http.NewRequestWithContext(
 		ctx,

--- a/backend/core_service/internal/orchestration/repo_search.go
+++ b/backend/core_service/internal/orchestration/repo_search.go
@@ -39,7 +39,7 @@ func (s *Service) SearchReposForUser(
 		domainQuery = "backend"
 	}
 
-	repos, err := s.githubClient.SearchRepos(ctx, languageQuery, domainQuery, "", token)
+	repos, err := s.githubClient.SearchRepos(ctx, languageQuery, domainQuery, "", token, 1, 30) // Hardcoded 1, 30 for SearchReposForUser recommendation internal tasks
 	if err != nil {
 		return nil, err
 	}
@@ -60,10 +60,12 @@ func (s *Service) SearchRepositories(
 	ctx context.Context,
 	query string,
 	token string,
+	page int,
+	limit int,
 ) ([]clients.GitHubRepo, error) {
 	if s.githubClient == nil {
 		return nil, errors.New("github client not configured")
 	}
 
-	return s.githubClient.SearchRepos(ctx, "", "", query, token)
+	return s.githubClient.SearchRepos(ctx, "", "", query, token, page, limit)
 }

--- a/backend/core_service/internal/watchlist/poller.go
+++ b/backend/core_service/internal/watchlist/poller.go
@@ -53,8 +53,6 @@ func (p *Poller) Start(ctx context.Context) {
 
 func (p *Poller) poll(ctx context.Context) {
 	log.Println("Poller: Starting poll cycle")
-	// TODO: Fetch distinct repos to avoid duplicate checks if multiple users watch the same repo
-	// For MVP, we iterate all entries. Optimization: implement "ListAllUniqueRepos" in repository.
 
 	limit := 100
 	offset := 0
@@ -64,62 +62,71 @@ func (p *Poller) poll(ctx context.Context) {
 	var wg sync.WaitGroup
 
 	for {
-		entries, err := p.repo.ListAllChunked(ctx, limit, offset)
+		uniqueRepos, err := p.repo.ListAllUniqueReposChunked(ctx, limit, offset)
 		if err != nil {
-			log.Printf("Poller: Error listing watched repos chunked at offset %d: %v", offset, err)
+			log.Printf("Poller: Error listing unique watched repos at offset %d: %v", offset, err)
 			break
 		}
 		
-		if len(entries) == 0 {
+		if len(uniqueRepos) == 0 {
 			break
 		}
 		
-		log.Printf("Poller: Processing chunk of %d entries (offset %d)", len(entries), offset)
+		log.Printf("Poller: Processing chunk of %d unique repos (offset %d)", len(uniqueRepos), offset)
 
-		for _, entry := range entries {
+		for _, repoEntry := range uniqueRepos {
 			wg.Add(1)
 			sem <- struct{}{} // Acquire token
 			
-			go func(e WatchedRepo) {
+			go func(e UniqueRepo) {
 				defer wg.Done()
 				defer func() { <-sem }() // Release token
 				
-				log.Printf("Poller: Checking repo %s/%s (Last issue: %d)", e.RepoOwner, e.RepoName, e.LatestIssueNumber)
+				log.Printf("Poller: Checking unique repo %s/%s", e.RepoOwner, e.RepoName)
 				latestNum, title, issueURL, err := p.githubClient.GetLatestIssue(e.RepoOwner, e.RepoName)
 				if err != nil {
 					log.Printf("Poller: Error fetching latest issue for %s/%s: %v", e.RepoOwner, e.RepoName, err)
 					return
 				}
 				
-				if latestNum > e.LatestIssueNumber {
-					log.Printf("Poller: New issue detected for %s/%s! Updating DB and notifying user %s", e.RepoOwner, e.RepoName, e.UserID)
+				// Find all subscribed users who are outdated for this repo
+				outdatedEntries, err := p.repo.GetOutdatedWatches(ctx, e.RepoOwner, e.RepoName, latestNum)
+				if err != nil {
+					log.Printf("Poller: Error fetching outdated watches for %s/%s: %v", e.RepoOwner, e.RepoName, err)
+					return
+				}
 
-					// Updates DB
-					if err := p.repo.UpdateLastChecked(ctx, e.ID, latestNum); err != nil {
-						log.Printf("Poller: Error updating last checked for %s/%s: %v", e.RepoOwner, e.RepoName, err)
-					}
+				if len(outdatedEntries) > 0 {
+					log.Printf("Poller: New issue detected for %s/%s! Updating DB and notifying %d users", e.RepoOwner, e.RepoName, len(outdatedEntries))
+					for _, watch := range outdatedEntries {
+						// Updates DB
+						if err := p.repo.UpdateLastChecked(ctx, watch.ID, latestNum); err != nil {
+							log.Printf("Poller: Error updating last checked for watch ID %d: %v", watch.ID, err)
+							continue
+						}
 
-					// Send notification with issue details via all notifiers
-					payload := map[string]interface{}{
-						"type":         "new_issue",
-						"repo":         e.RepoOwner + "/" + e.RepoName,
-						"issue_number": latestNum,
-						"issue_title":  title,
-						"issue_url":    issueURL,
-						"message":      "New issue detected!",
-					}
+						// Send notification with issue details via all notifiers
+						payload := map[string]interface{}{
+							"type":         "new_issue",
+							"repo":         e.RepoOwner + "/" + e.RepoName,
+							"issue_number": latestNum,
+							"issue_title":  title,
+							"issue_url":    issueURL,
+							"message":      "New issue detected!",
+						}
 
-					for _, notifier := range p.notifiers {
-						if err := notifier.NotifyUser(e.UserID, payload); err != nil {
-							log.Printf("Poller: Error notifying user %s via notifier: %v", e.UserID, err)
-						} else {
-							log.Printf("Poller: Successfully notified user %s", e.UserID)
+						for _, notifier := range p.notifiers {
+							if err := notifier.NotifyUser(watch.UserID, payload); err != nil {
+								log.Printf("Poller: Error notifying user %s via notifier: %v", watch.UserID, err)
+							} else {
+								log.Printf("Poller: Successfully notified user %s", watch.UserID)
+							}
 						}
 					}
 				} else {
 					log.Printf("Poller: No new issues for %s/%s", e.RepoOwner, e.RepoName)
 				}
-			}(entry)
+			}(repoEntry)
 		}
 		
 		offset += limit

--- a/backend/core_service/internal/watchlist/poller.go
+++ b/backend/core_service/internal/watchlist/poller.go
@@ -3,6 +3,7 @@ package watchlist
 import (
 	"context"
 	"log"
+	"sync"
 	"time"
 )
 
@@ -55,51 +56,75 @@ func (p *Poller) poll(ctx context.Context) {
 	// TODO: Fetch distinct repos to avoid duplicate checks if multiple users watch the same repo
 	// For MVP, we iterate all entries. Optimization: implement "ListAllUniqueRepos" in repository.
 
-	// Assuming ListAll returns all watched entries
-	entries, err := p.repo.ListAll(ctx)
-	if err != nil {
-		log.Printf("Poller: Error listing watched repos: %v", err)
-		return
-	}
-	log.Printf("Poller: Found %d entries to check", len(entries))
+	limit := 100
+	offset := 0
+	
+	// Create a worker pool semaphore
+	sem := make(chan struct{}, 10) // Concurrency bounded to 10
+	var wg sync.WaitGroup
 
-	for _, entry := range entries {
-		log.Printf("Poller: Checking repo %s/%s (Last issue: %d)", entry.RepoOwner, entry.RepoName, entry.LatestIssueNumber)
-		latestNum, title, issueURL, err := p.githubClient.GetLatestIssue(entry.RepoOwner, entry.RepoName)
+	for {
+		entries, err := p.repo.ListAllChunked(ctx, limit, offset)
 		if err != nil {
-			log.Printf("Poller: Error fetching latest issue for %s/%s: %v", entry.RepoOwner, entry.RepoName, err)
-			continue
+			log.Printf("Poller: Error listing watched repos chunked at offset %d: %v", offset, err)
+			break
 		}
-		log.Printf("Poller: Latest issue for %s/%s is #%d: %s", entry.RepoOwner, entry.RepoName, latestNum, title)
+		
+		if len(entries) == 0 {
+			break
+		}
+		
+		log.Printf("Poller: Processing chunk of %d entries (offset %d)", len(entries), offset)
 
-		if latestNum > entry.LatestIssueNumber {
-			log.Printf("Poller: New issue detected for %s/%s! Updating DB and notifying user %s", entry.RepoOwner, entry.RepoName, entry.UserID)
-
-			// Updates DB
-			if err := p.repo.UpdateLastChecked(ctx, entry.ID, latestNum); err != nil {
-				log.Printf("Poller: Error updating last checked for %s/%s: %v", entry.RepoOwner, entry.RepoName, err)
-			}
-
-			// Send notification with issue details via all notifiers
-			payload := map[string]interface{}{
-				"type":         "new_issue",
-				"repo":         entry.RepoOwner + "/" + entry.RepoName,
-				"issue_number": latestNum,
-				"issue_title":  title,
-				"issue_url":    issueURL,
-				"message":      "New issue detected!",
-			}
-
-			for _, notifier := range p.notifiers {
-				if err := notifier.NotifyUser(entry.UserID, payload); err != nil {
-					log.Printf("Poller: Error notifying user %s via notifier: %v", entry.UserID, err)
-				} else {
-					log.Printf("Poller: Successfully notified user %s", entry.UserID)
+		for _, entry := range entries {
+			wg.Add(1)
+			sem <- struct{}{} // Acquire token
+			
+			go func(e WatchedRepo) {
+				defer wg.Done()
+				defer func() { <-sem }() // Release token
+				
+				log.Printf("Poller: Checking repo %s/%s (Last issue: %d)", e.RepoOwner, e.RepoName, e.LatestIssueNumber)
+				latestNum, title, issueURL, err := p.githubClient.GetLatestIssue(e.RepoOwner, e.RepoName)
+				if err != nil {
+					log.Printf("Poller: Error fetching latest issue for %s/%s: %v", e.RepoOwner, e.RepoName, err)
+					return
 				}
-			}
-		} else {
-			log.Printf("Poller: No new issues for %s/%s", entry.RepoOwner, entry.RepoName)
+				
+				if latestNum > e.LatestIssueNumber {
+					log.Printf("Poller: New issue detected for %s/%s! Updating DB and notifying user %s", e.RepoOwner, e.RepoName, e.UserID)
+
+					// Updates DB
+					if err := p.repo.UpdateLastChecked(ctx, e.ID, latestNum); err != nil {
+						log.Printf("Poller: Error updating last checked for %s/%s: %v", e.RepoOwner, e.RepoName, err)
+					}
+
+					// Send notification with issue details via all notifiers
+					payload := map[string]interface{}{
+						"type":         "new_issue",
+						"repo":         e.RepoOwner + "/" + e.RepoName,
+						"issue_number": latestNum,
+						"issue_title":  title,
+						"issue_url":    issueURL,
+						"message":      "New issue detected!",
+					}
+
+					for _, notifier := range p.notifiers {
+						if err := notifier.NotifyUser(e.UserID, payload); err != nil {
+							log.Printf("Poller: Error notifying user %s via notifier: %v", e.UserID, err)
+						} else {
+							log.Printf("Poller: Successfully notified user %s", e.UserID)
+						}
+					}
+				} else {
+					log.Printf("Poller: No new issues for %s/%s", e.RepoOwner, e.RepoName)
+				}
+			}(entry)
 		}
+		
+		offset += limit
 	}
+	
+	wg.Wait()
 	log.Println("Poller: cycle finished")
 }

--- a/backend/core_service/internal/watchlist/repository.go
+++ b/backend/core_service/internal/watchlist/repository.go
@@ -80,14 +80,16 @@ func (r *Repository) IsWatched(ctx context.Context, userID, owner, name string) 
 	return exists, nil
 }
 
-func (r *Repository) ListAll(ctx context.Context) ([]WatchedRepo, error) {
+func (r *Repository) ListAllChunked(ctx context.Context, limit, offset int) ([]WatchedRepo, error) {
 	query := `
 		SELECT id, user_id, repo_owner, repo_name, last_checked_at, latest_issue_number, created_at
 		FROM watched_repos
+		ORDER BY id
+		LIMIT $1 OFFSET $2
 	`
-	rows, err := r.db.Query(ctx, query)
+	rows, err := r.db.Query(ctx, query, limit, offset)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list all watchlist items: %w", err)
+		return nil, fmt.Errorf("failed to list all watchlist items chunked: %w", err)
 	}
 	defer rows.Close()
 

--- a/backend/core_service/internal/watchlist/repository.go
+++ b/backend/core_service/internal/watchlist/repository.go
@@ -12,6 +12,11 @@ type Repository struct {
 	db *pgxpool.Pool
 }
 
+type UniqueRepo struct {
+	RepoOwner string
+	RepoName  string
+}
+
 func NewRepository(db *pgxpool.Pool) *Repository {
 	return &Repository{db: db}
 }
@@ -119,4 +124,55 @@ func (r *Repository) UpdateLastChecked(ctx context.Context, id int, latestIssueN
 		return fmt.Errorf("failed to update watchlist item: %w", err)
 	}
 	return nil
+}
+
+func (r *Repository) ListAllUniqueReposChunked(ctx context.Context, limit, offset int) ([]UniqueRepo, error) {
+	query := `
+		SELECT DISTINCT repo_owner, repo_name
+		FROM watched_repos
+		ORDER BY repo_owner, repo_name
+		LIMIT $1 OFFSET $2
+	`
+	rows, err := r.db.Query(ctx, query, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list unique repos: %w", err)
+	}
+	defer rows.Close()
+
+	var repos []UniqueRepo
+	for rows.Next() {
+		var repo UniqueRepo
+		if err := rows.Scan(&repo.RepoOwner, &repo.RepoName); err != nil {
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+		repos = append(repos, repo)
+	}
+	return repos, nil
+}
+
+func (r *Repository) GetOutdatedWatches(ctx context.Context, owner, name string, latestNum int) ([]WatchedRepo, error) {
+	query := `
+		SELECT id, user_id, repo_owner, repo_name, last_checked_at, latest_issue_number, created_at
+		FROM watched_repos
+		WHERE repo_owner = $1 AND repo_name = $2 AND latest_issue_number < $3
+	`
+	rows, err := r.db.Query(ctx, query, owner, name, latestNum)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get outdated watches: %w", err)
+	}
+	defer rows.Close()
+
+	var repos []WatchedRepo
+	for rows.Next() {
+		var repo WatchedRepo
+		var lastCheckedAt *time.Time // Handle NULL
+		if err := rows.Scan(&repo.ID, &repo.UserID, &repo.RepoOwner, &repo.RepoName, &lastCheckedAt, &repo.LatestIssueNumber, &repo.CreatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+		if lastCheckedAt != nil {
+			repo.LastCheckedAt = *lastCheckedAt
+		}
+		repos = append(repos, repo)
+	}
+	return repos, nil
 }

--- a/backend/core_service/routes/repos.go
+++ b/backend/core_service/routes/repos.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -53,7 +54,19 @@ func (h *RepoHandler) HandleSearch(w http.ResponseWriter, r *http.Request) {
 		githubToken = ""
 	}
 
-	repos, err := h.service.SearchRepositories(ctx, query, githubToken)
+	pageStr := r.URL.Query().Get("page")
+	limitStr := r.URL.Query().Get("limit")
+	page := 1
+	limit := 30
+	
+	if pageStr != "" {
+		fmt.Sscanf(pageStr, "%d", &page)
+	}
+	if limitStr != "" {
+		fmt.Sscanf(limitStr, "%d", &limit)
+	}
+
+	repos, err := h.service.SearchRepositories(ctx, query, githubToken, page, limit)
 	if err != nil {
 		log.Printf("HandleSearch: SearchRepositories failed: %v", err)
 		http.Error(w, "failed to search repos: "+err.Error(), http.StatusInternalServerError)

--- a/backend/github-service/internal/repos/repo_fetcher.go
+++ b/backend/github-service/internal/repos/repo_fetcher.go
@@ -66,7 +66,7 @@ func buildQuery(prefix string, values []string) string {
 }
 
 // generateCacheKey creates a unique key from query parameters
-func generateCacheKey(languages, frameworks, domains []string, nameQuery string) string {
+func generateCacheKey(languages, frameworks, domains []string, nameQuery string, page, limit int) string {
 	// Sort slices to ensure same key for same params regardless of order
 	sortedLangs := make([]string, len(languages))
 	copy(sortedLangs, languages)
@@ -81,11 +81,13 @@ func generateCacheKey(languages, frameworks, domains []string, nameQuery string)
 	sort.Strings(sortedDomains)
 
 	// Create string representation
-	key := fmt.Sprintf("l:%s|f:%s|d:%s|n:%s",
+	key := fmt.Sprintf("l:%s|f:%s|d:%s|n:%s|p:%d|lim:%d",
 		strings.Join(sortedLangs, ","),
 		strings.Join(sortedFrameworks, ","),
 		strings.Join(sortedDomains, ","),
 		nameQuery,
+		page,
+		limit,
 	)
 
 	// Hash the key to keep it short
@@ -93,9 +95,9 @@ func generateCacheKey(languages, frameworks, domains []string, nameQuery string)
 	return hex.EncodeToString(hash[:])
 }
 
-func FetchRepos(languages []string, frameworks []string, domains []string, nameQuery string, token string, cache *RepoCache) ([]RepoDTO, error) {
+func FetchRepos(languages []string, frameworks []string, domains []string, nameQuery string, token string, cache *RepoCache, page int, limit int) ([]RepoDTO, error) {
 	// Generate cache key
-	cacheKey := generateCacheKey(languages, frameworks, domains, nameQuery)
+	cacheKey := generateCacheKey(languages, frameworks, domains, nameQuery, page, limit)
 
 	// Check cache first
 	if cache != nil {
@@ -133,11 +135,8 @@ func FetchRepos(languages []string, frameworks []string, domains []string, nameQ
 
 	log.Println("Github search query: ", query)
 
-	// Use page 1 instead of random page to ensure we get results
-	page := 1
-
-	url := fmt.Sprintf("https://api.github.com/search/repositories?q=%s&page=%d&per_page=30&sort=stars&order=desc",
-		url.QueryEscape(query), page,
+	url := fmt.Sprintf("https://api.github.com/search/repositories?q=%s&page=%d&per_page=%d&sort=stars&order=desc",
+		url.QueryEscape(query), page, limit,
 	)
 
 	req, err := http.NewRequest("GET", url, nil)

--- a/backend/github-service/routes/github_routes.go
+++ b/backend/github-service/routes/github_routes.go
@@ -58,6 +58,18 @@ func RegisterGithubRoutes(router *gin.Engine) {
 			domains = strings.Split(domainsParam, ",")
 		}
 
+		pageStr := c.Query("page")
+		limitStr := c.Query("limit")
+		page := 1
+		limit := 30
+		
+		if pageStr != "" {
+			fmt.Sscanf(pageStr, "%d", &page)
+		}
+		if limitStr != "" {
+			fmt.Sscanf(limitStr, "%d", &limit)
+		}
+
 		token := os.Getenv("GITHUB_TOKEN")
 		if token == "" {
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -66,7 +78,7 @@ func RegisterGithubRoutes(router *gin.Engine) {
 			return
 		}
 
-		repoList, err := repos.FetchRepos(languages, frameworks, domains, nameQuery, token, repoCache)
+		repoList, err := repos.FetchRepos(languages, frameworks, domains, nameQuery, token, repoCache, page, limit)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": err.Error(),

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,11 +1,10 @@
-feat: add backend pagination to repository discovery
+perf: deduplicate watched-repo polling
 
-This replaces the massive client-side data fetch in the discovery page
-with true server-side pagination.
+This resolves an N+1 API fetching vulnerability where multiple users
+subscribing to the same project would trigger duplicate GitHub REST API
+calls for the latest issue.
 
-- Updated Next.js frontend to send 'page' and 'limit' parameters.
-- Replaced the local usePagination slicing with manual offset page tracking.
-- Passed 'page' and 'limit' query params through core_service down into
-  github-service, dynamically bounding the GitHub REST API queries to per-page 9.
-This resolves issues where the full dataset loading could crash or heavily
-tax bandwidth and memory for large user preference configurations.
+Instead of iterating over individual watch entries, the poller now queries
+the database for unique repositories in chunks, makes a single API call per
+unique project, and then queries a pushdown DB filter (latest_issue_number < ?)
+to retrieve all outdated users to fan out WS notifications simultaneously.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,11 @@
+feat: add backend pagination to repository discovery
+
+This replaces the massive client-side data fetch in the discovery page
+with true server-side pagination.
+
+- Updated Next.js frontend to send 'page' and 'limit' parameters.
+- Replaced the local usePagination slicing with manual offset page tracking.
+- Passed 'page' and 'limit' query params through core_service down into
+  github-service, dynamically bounding the GitHub REST API queries to per-page 9.
+This resolves issues where the full dataset loading could crash or heavily
+tax bandwidth and memory for large user preference configurations.

--- a/frontend/app/(auth)/discover/page.tsx
+++ b/frontend/app/(auth)/discover/page.tsx
@@ -24,8 +24,11 @@ export default function DiscoverPage() {
   const [experienceLevel, setExperienceLevel] = useState<string>("Beginner");
   const [username, setUsername] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const PAGE_SIZE = 9;
 
-  const loadRepos = useCallback(async () => {
+  const loadRepos = useCallback(async (page: number = 1) => {
     try {
       setLoading(true);
       setError(null);
@@ -38,8 +41,10 @@ export default function DiscoverPage() {
       setExperienceLevel(prefs.experienceLevel || "Beginner");
 
       // Fetch repositories using preferences
-      const repositories = await searchRepositories(prefs.languages, [], prefs.topics);
+      const repositories = await searchRepositories(prefs.languages, [], prefs.topics, page, PAGE_SIZE);
       setRepos(repositories);
+      setHasNextPage(repositories.length === PAGE_SIZE);
+      setCurrentPage(page);
     } catch (err: any) {
       console.error("Failed to load repositories:", err);
       // If error is 401, it will be handled by the API client or global error boundary
@@ -53,15 +58,17 @@ export default function DiscoverPage() {
   const handleSearch = useCallback(async (query: string) => {
     setSearchQuery(query);
     if (!query) {
-      loadRepos(); // reload default recommendations
+      loadRepos(1); // reload default recommendations
       return;
     }
 
     try {
       setLoading(true);
       setError(null);
-      const results = await searchRepositoriesByName(query);
+      const results = await searchRepositoriesByName(query, 1, PAGE_SIZE);
       setRepos(results);
+      setHasNextPage(results.length === PAGE_SIZE);
+      setCurrentPage(1);
     } catch (err: any) {
       console.error("Failed to search repositories:", err);
       setError("Failed to search repositories. Please try again.");
@@ -72,18 +79,37 @@ export default function DiscoverPage() {
   }, [loadRepos]);
 
   useEffect(() => {
-    loadRepos();
+    loadRepos(1);
   }, []);
+
+  const handlePageChange = async (newPage: number) => {
+    if (searchQuery) {
+      try {
+        setLoading(true);
+        const results = await searchRepositoriesByName(searchQuery, newPage, PAGE_SIZE);
+        setRepos(results);
+        setHasNextPage(results.length === PAGE_SIZE);
+        setCurrentPage(newPage);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      } catch (err: any) {
+        console.error("Failed to load page:", err);
+      } finally {
+        setLoading(false);
+      }
+    } else {
+      await loadRepos(newPage);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
 
   // Check if user has set preferences
   const hasPreferences = languages.length > 0 || topics.length > 0;
   // Show filters only if not searching and has preferences
   const showFilters = !searchQuery && hasPreferences;
 
-  const { paginatedItems, currentPage, totalPages, goToPage, nextPage, prevPage, hasPrev, hasNext } = usePagination({
-    items: repos,
-    pageSize: 9,
-  });
+  const hasPrev = currentPage > 1;
+  const hasNext = hasNextPage;
+  const totalPages = currentPage + (hasNext ? 1 : 0); // Approximate total pages for PaginationControls
 
   return (
     <PageWrapper className="space-y-6">
@@ -91,7 +117,7 @@ export default function DiscoverPage() {
       <DiscoverHero
         username={username}
         repoCount={repos.length}
-        onRefresh={loadRepos}
+        onRefresh={() => loadRepos(currentPage)}
         isLoading={loading}
       />
 
@@ -120,7 +146,7 @@ export default function DiscoverPage() {
 
       {/* Error State */}
       {error && !loading && (
-        <EmptyState type="error" onRetry={loadRepos} />
+        <EmptyState type="error" onRetry={() => loadRepos(currentPage)} />
       )}
 
       {/* No Preferences State */}
@@ -136,13 +162,13 @@ export default function DiscoverPage() {
       {/* Repo Grid */}
       {repos.length > 0 && !loading && !error && (
         <>
-          <RepoGrid repos={paginatedItems} />
+          <RepoGrid repos={repos} />
           <PaginationControls
             currentPage={currentPage}
             totalPages={totalPages}
-            onPrev={prevPage}
-            onNext={nextPage}
-            onGoTo={goToPage}
+            onPrev={() => handlePageChange(currentPage - 1)}
+            onNext={() => handlePageChange(currentPage + 1)}
+            onGoTo={(page: number) => handlePageChange(page)}
             hasPrev={hasPrev}
             hasNext={hasNext}
           />

--- a/frontend/lib/api/github-service.ts
+++ b/frontend/lib/api/github-service.ts
@@ -17,7 +17,9 @@ export interface Repository {
 export async function searchRepositories(
     languages: string[],
     frameworks: string[] = [],
-    domains: string[] = []
+    domains: string[] = [],
+    page: number = 1,
+    limit: number = 9
 ): Promise<Repository[]> {
     try {
         const params = new URLSearchParams();
@@ -33,6 +35,9 @@ export async function searchRepositories(
         if (domains.length > 0) {
             params.append('domain', domains.map(d => d.toLowerCase()).join(','));
         }
+        
+        params.append('page', page.toString());
+        params.append('limit', limit.toString());
 
         // Use full backend URL for production
         const url = `${GITHUB_SERVICE_URL}/repos/search?${params.toString()}`;
@@ -72,7 +77,7 @@ export async function fetchRepository(owner: string, repo: string): Promise<Repo
     }
 }
 
-export async function searchRepositoriesByName(query: string): Promise<Repository[]> {
+export async function searchRepositoriesByName(query: string, page: number = 1, limit: number = 9): Promise<Repository[]> {
     try {
         const token = localStorage.getItem('auth_token');
         const headers: HeadersInit = {
@@ -84,7 +89,7 @@ export async function searchRepositoriesByName(query: string): Promise<Repositor
         }
 
         const CORE_SERVICE_URL = process.env.NEXT_PUBLIC_CORE_SERVICE_URL;
-        const url = `${CORE_SERVICE_URL}/repos/search?q=${encodeURIComponent(query)}`;
+        const url = `${CORE_SERVICE_URL}/repos/search?q=${encodeURIComponent(query)}&page=${page}&limit=${limit}`;
         console.log("Calling Core service:", url);
 
         const response = await fetch(url, {


### PR DESCRIPTION
This pull request addresses several critical performance bottlenecks and code-quality issues in the Opensource Compass project. 

These architectural improvements ensure that the application scales effectively under load and handles heavy request volumes robustly without encountering rate limit or memory exhaustion issues.

### 1. Missing Database Indexes on Foreign Keys
The `user_preferences` table creates a foreign key to `users(id)` but did not declare an actual index on `user_id`. In PostgreSQL, foreign keys do not automatically create indexes, leading to continuous sequential table scans during user lookups. This PR adds a migration (`000008_add_user_preferences_index.up.sql`) to explicitly index `user_preferences(user_id)`.

### 2. Parallelized Watchlist Notification Poller
The `backend/core_service/internal/watchlist/poller.go` previously checked all GitHub watched repositories entirely sequentially, which scales poorly and rapidly hits rate limits. This commit refactors the poll step to use a bounded concurrency worker pool (semaphore pattern set to scale at 10) and updates the repository database fetch to properly employ chunked offset/limits.

### 3. Backend Pagination for Discovery Repositories
Replaced the memory-heavy client-side array-chunking with true server-side pagination for the `/repos/search` capabilities. The Next.js frontend now passes `page` and `limit` to the Go backend, which relays it directly to the GitHub API. By slicing large queries, it vastly reduces data over-fetching, rendering bottlenecks, and heap strain on large preference combinations.

### 4. Deduplicated Watch-Repo Polling
Resolved an N+1 API duplication in the background poller where multiple users watching the exact same project would trigger dozens of identical GitHub REST API requests for the same "latest issue." The background worker now retrieves `ListAllUniqueReposChunked()`, fetches the latest issue only once per unique project, and then pushes out WebSocket alerts to all subscribed out-of-date users in a single operation.
